### PR TITLE
Fix Dropflow for Vercel serverless environments

### DIFF
--- a/src/environment-node.ts
+++ b/src/environment-node.ts
@@ -1,10 +1,16 @@
 import {environment, defaultEnvironment} from './environment.js';
-import {fileURLToPath} from 'url';
+import {fileURLToPath} from 'node:url';
 import fs from 'node:fs';
+import path from 'node:path';
 
 if (environment.wasmLocator === defaultEnvironment.wasmLocator) {
   environment.wasmLocator = async () => {
-    return fs.readFileSync(new URL('../dropflow.wasm', import.meta.url));
+    return fs.readFileSync(
+      path.join(
+        path.dirname(fileURLToPath(import.meta.url)),
+        '../dropflow.wasm'
+      )
+    );
   };
 }
 


### PR DESCRIPTION
### Summary

In a local development environment I am working in, I experience an issue where one of the developer dependencies replaces the global URL. I am not sure who is specifically to blame there, but I did find that just changing the environment-node script to stop using URL allows me to use dropflow without any issues.

I don't believe this will cause any problems, so I figured I'd share my solution. If you'd rather not include this change, I can always just keep this as an internal patch on top of dropflow in my project.

The stack trace for the error looks like:
```
⨯ TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string or an instance of Buffer or URL. Received an instance of URL
    at Object.openSync (node:fs:563:5)
    at Object.readFileSync (node:fs:446:35)
    at Object.value (webpack-internal:///(rsc)/../../node_modules/dropflow/dist/src/api-wasm-locator-node.js:10:53)
```

Let me know your thoughts 🙇🏼 